### PR TITLE
fix: remove insecure global SSL certificate override

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -16,23 +15,10 @@ import 'package:mauritius_emergency_services/ui/utils/extensions.dart';
 import 'package:mauritius_emergency_services/ui/utils/getters.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-// Only enable this for development purposes
-// ad the following in main() -> HttpOverrides.global = MyHttpOverrides();
-class MyHttpOverrides extends HttpOverrides {
-  @override
-  HttpClient createHttpClient(SecurityContext? context) {
-    return super.createHttpClient(context)
-      ..badCertificateCallback =
-          (X509Certificate cert, String host, int port) => true;
-  }
-}
-
 // The main runner app
 void main() async {
   // Ensure the widgets are initialized
   final binding = WidgetsFlutterBinding.ensureInitialized();
-
-  HttpOverrides.global = MyHttpOverrides();
 
   // Preserve the splash screen
   FlutterNativeSplash.preserve(widgetsBinding: binding);


### PR DESCRIPTION
## Summary

- Removes `MyHttpOverrides` class which disables SSL/TLS certificate validation for **all** HTTP connections
- Removes `HttpOverrides.global = MyHttpOverrides()` from `main()`
- Removes the unused `dart:io` import

## Problem

`badCertificateCallback` returns `true` unconditionally, accepting any certificate including self-signed and expired ones. The comment says "Only enable this for development purposes" but the override is active in `main()` and ships to production builds.

This exposes users to man-in-the-middle attacks. An attacker on the same network (public WiFi, compromised router) can intercept API traffic and modify the response. For an emergency services app, this means an attacker could replace real emergency phone numbers with arbitrary ones.

## Fix

Delete the class and the global override entirely. Dart's default `HttpClient` validates certificates correctly out of the box. No replacement code is needed.

## Testing

- Verified the app compiles without the removed code
- Standard certificate validation (Dart default) will reject invalid certificates and accept valid ones
- The API at `https://mes.plagueworks.org` uses a valid certificate and will continue to work