### PR TITLE
fix: sanitize phone numbers before constructing tel: URIs

### DIFF
--- a/lib/ui/pages/precall/precall_views.dart
+++ b/lib/ui/pages/precall/precall_views.dart
@@ -411,12 +411,16 @@ void onCountdownComplete({
   required Function() onError,
 }) async {
   if (Platform.isAndroid) {
+    // Strip non-digit characters to prevent tel: URI injection
+    // (e.g. DTMF tones via ';', ',', '#', '*')
+    final sanitized = number.sanitizeForTelUri();
+
     // Define the data
-    String numberUri = 'tel:$number';
+    String numberUri = 'tel:$sanitized';
 
     // Check if the number is an emergency number
     if (service.type.toUpperCase() == "E") {
-      numberUri = 'tel:$number+';
+      numberUri = 'tel:$sanitized+';
     }
 
     // Build the android intent
@@ -428,8 +432,8 @@ void onCountdownComplete({
     // Launch the intent
     await intent.launch();
   } else {
-    // Build the URI
-    final uri = Uri(scheme: 'tel', path: number);
+    // Build the URI with sanitized number
+    final uri = Uri(scheme: 'tel', path: number.sanitizeForTelUri());
 
     // Launch the URL with explicit LaunchMode
     if (!await launchUrl(uri)) {

--- a/lib/ui/utils/extensions.dart
+++ b/lib/ui/utils/extensions.dart
@@ -118,6 +118,17 @@ extension StringExtension on String {
     return int.tryParse(this) != null;
   }
 
+  /// Strips all characters except digits and leading '+' to prevent
+  /// tel: URI injection (e.g. DTMF tones via `;`, `,`, `#`, `*`).
+  String sanitizeForTelUri() {
+    // Keep only digits and a leading '+' for international format
+    final digits = replaceAll(RegExp(r'[^\d]'), '');
+    if (startsWith('+')) {
+      return '+$digits';
+    }
+    return digits;
+  }
+
   List<Pair<String, String>> getStyleHeaderName() {
     // Split the name
     final names = split(" ");


### PR DESCRIPTION
## Summary

- Adds `sanitizeForTelUri()` extension on `String` that strips all characters except digits and a leading `+`
- Applies sanitization in `onCountdownComplete()` on both the Android intent path and the iOS `url_launcher` path

## Problem

Phone numbers are interpolated directly into `tel:` URIs without stripping control characters. Android's dialer interprets several characters within `tel:` URIs as protocol commands:

| Character | Behavior |
|-----------|----------|
| `;` | Wait, then dial the following digits |
| `,` | Pause for 2 seconds, then continue dialing |
| `#` | Send as DTMF tone |
| `*` | Send as DTMF tone |

A compromised or spoofed API response could inject these characters into phone number fields. For example, a `mainContact` value of `999;1900123456` would construct `tel:999;1900123456`, causing the dialer to call 999 (police) and then automatically dial a secondary number.

While the current data model stores `mainContact` as `int` (which limits the attack surface), the `number` parameter in `onCountdownComplete()` is a `String` and should be sanitized as defense-in-depth. If the model ever changes to `String` (e.g. to support international format with `+` prefix), the injection vector would open up without this protection.

## Fix

`sanitizeForTelUri()` removes everything except `[0-9]` and preserves a leading `+` for international numbers. Applied at the point where the URI is constructed, not at the model layer, to keep the change minimal and focused.

## Testing

- Verified the extension strips `;`, `,`, `#`, `*` and other non-digit characters
- Verified leading `+` is preserved for international format numbers
- Verified normal digit-only numbers pass through unchanged
- Both Android (`AndroidIntent`) and iOS (`url_launcher`) paths are covered